### PR TITLE
Update CI workflow to use GH_PAT environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+          GH_PAT: ${{ secrets.GH_PAT }}
           AIRTABLE_PAT: ${{ secrets.AIRTABLE_PAT }}
           AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }} 


### PR DESCRIPTION
- Changed the environment variable name from GITHUB_PAT to GH_PAT in the CI workflow configuration for consistency with recent updates across the project.